### PR TITLE
feat(system): system page from agent/editor — Playtest 6

### DIFF
--- a/src/lib/utils/agent-content-loaders/system-prompt-loader.ts
+++ b/src/lib/utils/agent-content-loaders/system-prompt-loader.ts
@@ -1,0 +1,7 @@
+import { loadAgentFile } from './agent-content-loader';
+
+const PROMPT_FILE_PATH = '/docs/system-prompt.md';
+
+export const loadSystemBasePrompt = async () => {
+  return await loadAgentFile(PROMPT_FILE_PATH);
+};

--- a/src/routes/(app)/system/+page.svelte
+++ b/src/routes/(app)/system/+page.svelte
@@ -1,0 +1,114 @@
+<script lang="ts"> 
+	import { dialogService } from '$lib/services/dialog-service.svelte';
+	import { loadBestiaryAsMD } from '$lib/utils/agent-content-loaders/bestiary-loader.js';
+	import {
+		loadAbilityCardsAsMD,
+		loadMagicalItemsCardsAsMD,
+	} from '$lib/utils/agent-content-loaders/cards-loader.js';
+	import { loadGMManual } from '$lib/utils/agent-content-loaders/gm-manual-loader.js';
+	import { loadPlayerManual } from '$lib/utils/agent-content-loaders/player-manual-loader.js';
+	import { loadSystemBasePrompt } from '$lib/utils/agent-content-loaders/system-prompt-loader';
+	import { onMount } from 'svelte';
+
+	let prompt = $state('');
+
+	const copyPromptToClipboard = async () => {
+		try {
+			await navigator.clipboard.writeText(prompt);
+			await dialogService.alert('Prompt copiado al portapapeles');
+		} catch (err) {
+			console.error('Failed to copy text: ', err);
+			await dialogService.alert('Error al copiar el prompt al portapapeles');
+		}
+	};
+
+	const loadPrompt = async () => {
+		const [basePrompt, playerManual, gmManual, bestiary, cardsList, magicalItems] =
+			await Promise.all([
+				loadSystemBasePrompt(),
+				loadPlayerManual(),
+				loadGMManual(),
+				loadBestiaryAsMD(),
+				loadAbilityCardsAsMD(),
+				loadMagicalItemsCardsAsMD(),
+			]);
+
+		let doc = basePrompt;
+
+		const replacement_variables = [
+			{
+				variable: 'player_manual',
+				value: playerManual,
+			},
+			{
+				variable: 'game_master_manual',
+				value: gmManual,
+			},
+			{
+				variable: 'bestiary',
+				value: bestiary,
+			},
+			{
+				variable: 'cards_list',
+				value: cardsList,
+			},
+			{
+				variable: 'magical_items',
+				value: magicalItems,
+			},
+		];
+
+		for (const x of replacement_variables) {
+			doc = doc.replace(`{{${x.variable}}}`, x.value);
+		}
+		prompt = doc;
+	};
+
+	onMount(async () => await loadPrompt());
+</script>
+
+<section>
+	<h1>IA como Sistema (System)</h1>
+	<p>
+		A continuación hay un prompt que expone todo el contenido del sistema para automatizaciones y procesos que
+		requieran el contenido completo de Arcana.
+	</p>
+	<p>
+		Para utilizarlo, simplemente copia el prompt, pegalo en tu AI favorita y ¡a trabajar!
+	</p>
+
+	<div class="prompt-header">
+		<h2>Prompt</h2>
+		<button onclick={copyPromptToClipboard}>Copiar Prompt</button>
+	</div>
+	<pre>{prompt}</pre>
+</section>
+
+<style>
+	section {
+		display: flex;
+		flex-direction: column;
+		padding: var(--spacing-md);
+
+		.prompt-header {
+			display: flex;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+			width: 100%;
+			flex-wrap: wrap;
+		}
+
+		pre {
+			white-space: pre-wrap;
+			border: 1px solid var(--border-color);
+			border-radius: var(--radius-md);
+			background-color: var(--disabled-bg);
+			padding: var(--spacing-sm);
+		}
+	}
+	:global(pre) {
+		background-color: lightgray;
+		white-space: pre-wrap;
+	}
+</style>

--- a/static/docs/system-prompt.md
+++ b/static/docs/system-prompt.md
@@ -1,0 +1,38 @@
+---
+title: 'Arcana RPG - Playtest 6 (System Prompt)'
+version: Playtest 6
+---
+
+# Arcana RPG
+
+Este documento corresponde a la versión Playtest 6 del sistema de rol Arcana. A continuación se presentan los documentos de referencia del sistema.
+
+### Manual del Jugador
+
+<player_manual>
+{{player_manual}}
+</player_manual>
+
+### Manual del Director de Juego
+
+<game_master_manual>
+{{game_master_manual}}
+</game_master_manual>
+
+### Bestiario
+
+<bestiary>
+{{bestiary}}
+</bestiary>
+
+### Listado de Cartas
+
+<cards_list>
+{{cards_list}}
+</cards_list>
+
+### Listado de Objetos Mágicos
+
+<magical_items>
+{{magical_items}}
+</magical_items>


### PR DESCRIPTION
Agrega template de prompt para /system (Playtest 6). Reusa la lógica de /agent y /editor. Formateado con prettier/eslint.